### PR TITLE
Add bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,14 @@
+{
+  "name": "ng-snackbar",
+  "description": "A message snackbar for Angular",
+  "main": "src/ng-snackbar.js",
+  "authors": [
+    "Henry Gordon"
+  ],
+  "license": "ISC",
+  "keywords": [
+    "snackbar",
+    "angular"
+  ],
+  "homepage": "https://github.com/hwgordon247/ng-snackbar"
+}


### PR DESCRIPTION
bower.json is useful in some cases. For example it is required for  https://github.com/taptapship/wiredep 